### PR TITLE
section name UTF16 problem

### DIFF
--- a/OZMTool/ozmtool.cpp
+++ b/OZMTool/ozmtool.cpp
@@ -731,14 +731,16 @@ UINT8 OZMTool::Kext2Ffs(QString inputdir, QString outputdir)
             return ERR_ERROR;
         }
 
-        filepath = pathConcatenate(outputdir, currKext.baseName() + "Kext" + ".ffs");
+        // use std filenaming for kexts
+        filepath = pathConcatenate(outputdir, currKext.baseName() /*+ "Kext"*/ + ".ffs");
         fileWrite(filepath, out);
         if(ret) {
             printf("ERROR: Saving '%s' failed!\n", qPrintable(filepath));
             return ERR_ERROR;
         }
 
-        filepath = pathConcatenate(outputdir, currKext.fileName() + ".ffs.compressed");
+        // use std filenaming for kexts
+        filepath = pathConcatenate(outputdir, currKext.baseName() /*.fileName()*/ + ".ffs.compressed");
         fileWrite(filepath, compressedOut);
         if(ret) {
             printf("ERROR: Saving '%s' failed!\n", qPrintable(filepath));

--- a/OZMTool/util.cpp
+++ b/OZMTool/util.cpp
@@ -289,9 +289,9 @@ UINT8 convertKext(QString input, QString guid, QString basename, QByteArray & ou
     if (ret) {
         printf("Info: Unable to get version string...\n");
         sectionName = basename;
-    }
-    else
+    } else {
         sectionName.sprintf("%s.Rev-%s",qPrintable(basename), qPrintable(bundleVersion));
+    }
 
     toConvertBinary.append(plistbuf);
     toConvertBinary.append(nullterminator);
@@ -428,7 +428,13 @@ UINT8 freeformCreate(QByteArray binary, QString guid, QString sectionName, QByte
         printf("ERROR: Failed to create PE32 Section!\n");
         return ERR_ERROR;
     }
-    ret = sectionCreate(QByteArray((const char*)sectionName.utf16()), EFI_SECTION_USER_INTERFACE, userSection);
+
+    // somehow this doesn't create the correct UTF string
+    // ret = sectionCreate(QByteArray((const char*)sectionName.utf16()), EFI_SECTION_USER_INTERFACE, userSection);
+    // use workaround
+    QByteArray ba;
+    ba.append( (const char*) sectionName.utf16(), sectionName.size() * 2 );
+    ret = sectionCreate(ba, EFI_SECTION_USER_INTERFACE, userSection);
     if (ret) {
         printf("ERROR: Failed to create User Interface Section!\n");
         return ERR_ERROR;


### PR DESCRIPTION
- bugfix: section name isn't converted to utf16 correctly
- kext files are named correctly
